### PR TITLE
fix/framework-single-row

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 	<link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&display=swap" rel="stylesheet">
 
 	<!-- load custom CSS -->
-	<link href="css/style.css?cache=9215" rel="stylesheet" type="text/css" media="all" />
+	<link href="css/style.css?cache=9220" rel="stylesheet" type="text/css" media="all" />
 
 </head>
 
@@ -226,14 +226,14 @@
 
 <!-- load custom JavaScript -->
 <script type="text/javascript" src="js/geojson-rewind.js"></script>
-<script type="text/javascript" src="js/map.js?cache=9215"></script>
-<script type="text/javascript" src="js/framework.js?cache=9215"></script>
-<script type="text/javascript" src="js/summary.js?cache=9215"></script>
-<script type="text/javascript" src="js/parse-data.js?cache=9215"></script>
-<script type="text/javascript" src="js/deepviz.js?cache=9215"></script>
-<script type="text/javascript" src="js/barchart.js?cache=9215"></script>
-<script type="text/javascript" src="js/humanitarianprofile.js?cache=9215"></script>
-<script type="text/javascript" src="js/main.js?cache=9215"></script>
+<script type="text/javascript" src="js/map.js?cache=9220"></script>
+<script type="text/javascript" src="js/framework.js?cache=9220"></script>
+<script type="text/javascript" src="js/summary.js?cache=9220"></script>
+<script type="text/javascript" src="js/parse-data.js?cache=9220"></script>
+<script type="text/javascript" src="js/deepviz.js?cache=9220"></script>
+<script type="text/javascript" src="js/barchart.js?cache=9220"></script>
+<script type="text/javascript" src="js/humanitarianprofile.js?cache=9220"></script>
+<script type="text/javascript" src="js/main.js?cache=9220"></script>
 
 	
 </body>

--- a/js/deepviz.js
+++ b/js/deepviz.js
@@ -83,7 +83,7 @@ var margin = {top: 18, right: 17, bottom: 0, left: 45};
 var timechartHeight = 330;
 var timechartHeight2 = timechartHeight;
 var timechartHeightOriginal = timechartHeight;
-var timechartSvgHeight = 900;
+var timechartSvgHeight = 1000;
 var brush;
 var gBrush; 
 var barWidth;
@@ -110,7 +110,7 @@ var curvedLine = d3.line()
 // map
 var maxMapBubbleValue;
 var maxMapPolygonValue;
-var mapAspectRatio = 1.2;
+var mapAspectRatio = 1.33;
 var geoBounds = {'lat': [], 'lon': []};
 
 // filters
@@ -1623,7 +1623,7 @@ var Deepviz = function(sources, callback){
 
 		contextualRows.append('rect')
 		.attr('height', contextualRowsHeight+45)
-		.attr('width', 10)
+		.attr('width',6)
 		.attr('x', -5)
 		.attr('y',-30)
 		.style('fill', '#FFF')
@@ -1662,7 +1662,7 @@ var Deepviz = function(sources, callback){
 		})
 		.attr('class', 'label')
 		.attr('y',18)
-		.attr('x',4)
+		.attr('x',-2)
 		// .style('font-weight', 'bold')
 		.style('font-size', '16px');
 
@@ -3010,7 +3010,7 @@ var Deepviz = function(sources, callback){
 			var timelineSvg = Deepviz.createSvg({
 				id: 'timeline_viz',
 				viewBoxWidth: w,
-				viewBoxHeight: 900,
+				viewBoxHeight: timechartSvgHeight,
 				div: '#timeline'
 			});
 

--- a/js/deepviz.js
+++ b/js/deepviz.js
@@ -2006,7 +2006,6 @@ var Deepviz = function(sources, callback){
 	    	dateRange[1].setHours(0,0,0,0);
 	    	dateRange[1] = moment(dateRange[1].setDate(dateRange[1].getDate())).add(1, 'day');
 	    	gBrush.call(brush.move, dateRange.map(scale.timechart.x));
-
 		    update();
 		});
 
@@ -2160,7 +2159,7 @@ var Deepviz = function(sources, callback){
 			// colorBars();
 			updateDate();
 			Summary.update();
-			if(disableSync==false){
+			if((disableSync==false)||(d3.event.sourceEvent==null)){
 				DeepvizFramework.updateFramework();
 				Map.update();
 				updateSeverityReliability('brush');

--- a/js/framework.js
+++ b/js/framework.js
@@ -7,6 +7,23 @@ var tooltipSvg;
 
 DeepvizFramework.create = function(a){
 
+	// handle metadata with single-rows
+	var count = 0;
+	var contextId = null;
+	metadata.framework_groups_array.forEach(function(d,i){
+		if(contextId==d.context_id){
+			count++;
+		} else {
+			if(count==1){
+				var row = {'id': -1, 'context_id': metadata.framework_groups_array[i-1].context_id, 'name': '', 'tooltip': ''};
+				metadata.framework_groups_array.splice((i),0,row);
+			} else {
+				count = 1;
+			}
+		} 
+		contextId=d.context_id;
+	});
+
 	var frameworkRowHeight = 28;
 	var frameworkHeight = metadata.framework_groups_array.length * frameworkRowHeight;
 
@@ -345,7 +362,7 @@ DeepvizFramework.create = function(a){
 	.style('fill', colorLightgrey[3])
 	.style('cursor', 'pointer')
 	.style('opacity', 0)
-	.on('mouseover', function(d,i){
+	.on('mouseover', function(d,i){		
 		if(filters['context'].includes(parseInt(d.key))){
 			// return d3.select(this).style('fill', '#FFF').style('opacity',0.5);
 		} else {
@@ -376,15 +393,20 @@ DeepvizFramework.create = function(a){
 
 	// 2nd col filters
 	d3.selectAll('.frameworkRowSelector')
-	.style('cursor', 'pointer')
+	.style('cursor', function(d,i){
+		if(d.name.length>1) return 'pointer';
+	})
 	.on('mouseover', function(d,i){
+		if(d.name.length>1)
 		return d3.select('.frameworkRowSelector-'+d.id+'.frameworkRowSelector-bg').style('fill', colorGrey[2]).style('opacity', 0.05);	
 	})
 	.on('mouseout', function(d,i){
 		d3.selectAll('.frameworkRowSelector-bg').style('fill', '#FFF');
 	}).on('click', function(d,i){
-		d3.selectAll('.frameworkRowSelector-bg').style('fill', '#FFF');
-		Deepviz.filter('framework',d.id);
+		if(d.name.length>1){
+			d3.selectAll('.frameworkRowSelector-bg').style('fill', '#FFF');
+			Deepviz.filter('framework',d.id);
+		}
 	});
 
 	// sparkline containers
@@ -611,7 +633,6 @@ DeepvizFramework.create = function(a){
         	var sectorId = d3.select(cell.node().parentNode).attr('data-sector');
         	
         	var path = DeepvizFramework.updateTooltipSparkline(contextId, frameworkId, sectorId);
-
 	        html=html+'<br/><svg style="margin-top: 1px; margin-bottom: 1px" id="tooltipSparkline" width="'+tooltipSparklineWidth+'px" height="'+tooltipSparklineHeight+'px">'+path.node().outerHTML+'</svg>';
         	instance.setContent(html);
 
@@ -1247,7 +1268,6 @@ DeepvizFramework.updateTooltipSparkline = function(contextId, frameworkId, secto
 			}
 		})		
 		.entries(dataByDateSparkline);
-
 	}
 
 	if(filters.time=='m'){
@@ -1319,7 +1339,7 @@ DeepvizFramework.updateTooltipSparkline = function(contextId, frameworkId, secto
 
 	var filteredSparklineData = dataByDateSparkline.filter(function(d){ 
     	return d.value.total>0; 
-    })
+    });
 
     if(contextMax>0){
 

--- a/js/main.js
+++ b/js/main.js
@@ -46,7 +46,7 @@ var Deepviz = new Deepviz(sources, function(data){
 	var timelineSvg = Deepviz.createSvg({
 		id: 'timeline_viz',
 		viewBoxWidth: 1300,
-		viewBoxHeight: 900,
+		viewBoxHeight: timechartSvgHeight,
 		div: '#timeline'
 	});
 

--- a/js/map.js
+++ b/js/map.js
@@ -200,7 +200,6 @@ Map.create = function(){
 	if (url.searchParams.get('mapboxStyle')) {
 		mapboxStyle = url.searchParams.get('mapboxStyle');
 		$('#map-bg-toggle select').val(mapboxStyle);
-
 	}
 
     //Setup mapbox-gl map
@@ -280,7 +279,7 @@ Map.create = function(){
 		    map.boxZoom.disable();
 			// change cursor
 			d3.select('#map-bubble-svg').style('cursor', 'crosshair');
-
+			console.log('lassoactive');
 		} else {
 			lassoActive = false;
 			$('#lasso-selected').hide();
@@ -544,8 +543,8 @@ Map.createBubbles = function(){
 	.attr("fill", "#FFF")
 	.attr('cx', 0)
 	.attr('cy', 0)
-	.attr('r' , 30)
-	.attr("stroke-width", 2);
+	.attr('r' , 28)
+	.attr("stroke-width", 4);
 
 	featureElementG
 	.append("circle")
@@ -553,7 +552,7 @@ Map.createBubbles = function(){
 	.attr("fill", colorNeutral[3])
 	.attr('cx', 0)
 	.attr('cy', 0)
-	.attr('r' , 26)
+	.attr('r' , 25)
 	.attr("stroke-width", 0);
 
 	featureElementG
@@ -1024,11 +1023,12 @@ Map.updateBubbles = function(){
 	d3.select('#map-polygons').style('display', 'none');
 
 	d3.select('#map-grid-svg').style('display', 'none');
-
-	map.dragPan.enable();
-	map.doubleClickZoom.enable();
+	if(lassoActive!=true){
+		map.dragPan.enable();
+		map.doubleClickZoom.enable();	
+		d3.selectAll('#map-bubble-svg').style('cursor','grab');
+	}
 	$('#map-bg-toggle').show();
-	d3.selectAll('#map-bubble-svg').style('cursor','grab');
 	d3.selectAll('#map-bubble-svg .bubble').style('cursor','pointer');
 
 	// bubbles display severity/reliability
@@ -1107,22 +1107,42 @@ Map.updateBubbles = function(){
 		});
 
 		if(filters.toggle=='severity'){
-			featureElementG.select('.innerCircle').style('fill', function(d,i){ return colorPrimary[d.median]});
+			featureElementG.select('.innerCircle').style('fill', function(d,i){ 
+				if((filters.geo.length==0)||(filters.geo.includes(d.id))){
+					return colorPrimary[d.median];
+				} else { 
+					return colorGrey[1]; 
+				}
+			});
 			featureElementG.select('.outerCircle').attr('stroke', function(d,i){ 
 				if(filters.geo.includes(d.id)){
 					return 'cyan';
 				} else {
-					return colorPrimary[d.median]
+					if(filters.geo.length>0){
+						return colorGrey[1];
+					} else {
+						return colorPrimary[d.median];
+					}
 				}
 			});
 
 		} else {
-			featureElementG.select('.innerCircle').style('fill', function(d,i){ return colorSecondary[d.median]});
+			featureElementG.select('.innerCircle').style('fill', function(d,i){ 
+				if((filters.geo.length==0)||(filters.geo.includes(d.id))){
+					return colorSecondary[d.median];
+				} else { 
+					return colorGrey[1]; 
+				}
+			});
 			featureElementG.select('.outerCircle').attr('stroke', function(d,i){ 
 				if(filters.geo.includes(d.id)){
 					return 'cyan';
 				} else {
-					return colorSecondary[d.median]
+					if(filters.geo.length>0){
+						return colorGrey[1];
+					} else {
+						return colorSecondary[d.median];
+					}
 				}
 			});
 		}
@@ -1197,51 +1217,25 @@ Map.updateBubbles = function(){
 			return d.total;
 		})
 
-		featureElementG.select('.innerCircle').style('fill', colorNeutral[3]);
+		featureElementG.select('.innerCircle').style('fill', function(d,i){ 
+			if((filters.geo.length==0)||(filters.geo.includes(d.id))){
+				return colorNeutral[3];
+			} else { 
+				return colorGrey[1]; 
+			}
+		});
+
 		featureElementG.select('.outerCircle').attr('stroke', function(d,i){ 
-				if(filters.geo.includes(d.id)){
-					return 'cyan';
+			if(filters.geo.includes(d.id)){
+				return 'cyan';
+			} else {
+				if(filters.geo.length>0){
+					return colorGrey[1];
 				} else {
-					return colorNeutral[3]
+					return colorNeutral[3];
 				}
-			});
-
-		// bubbles.forEach(function(d,i){
-
-		// 	var geo = metadata.geo_array[d.key-1];
-		// 	var tot = d.value.total;
-
-		// 	if(tot>0){
-		// 		d3.selectAll('#bubble'+(d.key-1)).style('display', 'block').select('.map-bubble')
-		// 		.attr('transform', function(d,i){
-		// 			var size = scale.map(tot);
-		// 			return 'scale('+size+')';
-		// 		}).style('opacity', 1).style('display', 'block');
-		// 	} 
-		// 	d3.selectAll('#bubble'+(d.key-1)+' .map-bubble-value').text(d.value.total);
-
-		// 	// d3.selectAll('.innerCircle').style('fill', colorNeutral[3]);
-		// 	// d3.selectAll('.outerCircle').attr('stroke', colorNeutral[3]);
-
-		// 	if(filters.frameworkToggle=='entries'){
-		// 		d3.selectAll('#bubble'+(d.key-1)+ ' .innerCircle').style('fill', colorNeutral[3]);
-		// 		d3.selectAll('#bubble'+(d.key-1)+ ' .outerCircle').attr('stroke', colorNeutral[3]);
-		// 	} else {
-		// 		if(filters.toggle=='severity'){
-		// 			d3.selectAll('#bubble'+(d.key-1)+ ' .innerCircle').style('fill', colorPrimary[d.value.value]);
-		// 			d3.selectAll('#bubble'+(d.key-1)+ ' .outerCircle').attr('stroke', colorPrimary[d.value.value]);
-		// 		} else {
-		// 			d3.selectAll('#bubble'+(d.key-1)+ ' .innerCircle').style('fill', colorSecondary[d.value.value]);
-		// 			d3.selectAll('#bubble'+(d.key-1)+ ' .outerCircle').attr('stroke', colorSecondary[d.value.value]);
-		// 		}
-		// 	}
-
-		// 	if(filters.geo.includes(geo.id)){
-		// 		d3.selectAll('#bubble'+(d.key-1)+ ' .outerCircle').attr('stroke', 'cyan');
-		// 	}
-			
-		// });
-
+			}
+		});
 	}
 
 }


### PR DESCRIPTION
in cases where there is a single framework row, there is no space for the sparkline to be drawn. this fix inserts an empty row in the framework table in cases where there is only one row. 

from this - 
![Screenshot 2020-08-31 at 17 47 55](https://user-images.githubusercontent.com/3186357/91733482-3f7bb780-ebb2-11ea-973e-af5a5da13e39.jpg)

to this - 
![Screenshot 2020-08-31 at 17 47 45](https://user-images.githubusercontent.com/3186357/91733505-46a2c580-ebb2-11ea-86c3-41a1df118b2d.jpg)
